### PR TITLE
Added two rules

### DIFF
--- a/php-custom-rules/src/main/java/org/sonar/samples/php/MyPhpRules.java
+++ b/php-custom-rules/src/main/java/org/sonar/samples/php/MyPhpRules.java
@@ -31,8 +31,10 @@ import java.util.Map;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.server.rule.RulesDefinitionAnnotationLoader;
 import org.sonar.plugins.php.api.visitors.PHPCustomRuleRepository;
+import org.sonar.samples.php.checks.FieldNameWithUnderScorePrefixUseCheck;
 import org.sonar.samples.php.checks.ForbiddenFunctionUseCheck;
 import org.sonar.samples.php.checks.OtherForbiddenFunctionUseCheck;
+import org.sonar.samples.php.checks.ProtectedMembersUseCheck;
 
 /**
  * Extension point to define a PHP rule repository.
@@ -53,12 +55,15 @@ public class MyPhpRules implements RulesDefinition, PHPCustomRuleRepository {
    */
   @Override
   public ImmutableList<Class> checkClasses() {
-    return ImmutableList.of(ForbiddenFunctionUseCheck.class, OtherForbiddenFunctionUseCheck.class);
+    return ImmutableList.of(ForbiddenFunctionUseCheck.class,
+            ProtectedMembersUseCheck.class,
+            FieldNameWithUnderScorePrefixUseCheck.class,
+            OtherForbiddenFunctionUseCheck.class);
   }
 
   @Override
   public void define(Context context) {
-    NewRepository repository = context.createRepository(repositoryKey(), "php").setName("MyCompany Custom Repository");
+    NewRepository repository = context.createRepository(repositoryKey(), "php").setName("Demo php Repository");
 
     // Load rule meta data from annotations
     RulesDefinitionAnnotationLoader annotationLoader = new RulesDefinitionAnnotationLoader();
@@ -71,6 +76,8 @@ public class MyPhpRules implements RulesDefinition, PHPCustomRuleRepository {
     Map<String, String> remediationCosts = new HashMap<>();
     remediationCosts.put(ForbiddenFunctionUseCheck.KEY, "5min");
     remediationCosts.put(OtherForbiddenFunctionUseCheck.KEY, "5min");
+    remediationCosts.put(ProtectedMembersUseCheck.KEY, "5min");
+    remediationCosts.put(FieldNameWithUnderScorePrefixUseCheck.KEY, "5min");
     repository.rules().forEach(rule -> rule.setDebtRemediationFunction(
       rule.debtRemediationFunctions().constantPerIssue(remediationCosts.get(rule.key()))));
 

--- a/php-custom-rules/src/main/java/org/sonar/samples/php/checks/FieldNameWithUnderScorePrefixUseCheck.java
+++ b/php-custom-rules/src/main/java/org/sonar/samples/php/checks/FieldNameWithUnderScorePrefixUseCheck.java
@@ -1,0 +1,108 @@
+/*
+ * SonarQube PHP Custom Rules Example
+ * Copyright (C) 2016-2016 SonarSource SA
+ * mailto:contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.samples.php.checks;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import org.sonar.check.Priority;
+import org.sonar.check.Rule;
+import org.sonar.php.api.PHPKeyword;
+import org.sonar.plugins.php.api.tree.Tree;
+import org.sonar.plugins.php.api.tree.Tree.Kind;
+import org.sonar.plugins.php.api.tree.declaration.ClassPropertyDeclarationTree;
+import org.sonar.plugins.php.api.tree.declaration.VariableDeclarationTree;
+import org.sonar.plugins.php.api.visitors.PHPSubscriptionCheck;
+import org.sonar.plugins.php.api.visitors.PHPVisitorCheck;
+
+import java.util.List;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+/**
+ * Example of implementation of a check by extending {@link PHPVisitorCheck}.
+ * PHPVisitorCheck provides methods to visit nodes of the Abstract Syntax Tree
+ * that represents the source code.
+ * <p>
+ * Those methods can be overridden to process information
+ * related to node and issue can be created via the context that can be
+ * accessed through {@link PHPVisitorCheck#context()}.
+ */
+@Rule(
+  key = FieldNameWithUnderScorePrefixUseCheck.KEY,
+  priority = Priority.MAJOR,
+  name = "Property name should not be prefixed with an underscore to indicate visibility.",
+  tags = {"convention"},
+// Description can either be given in this annotation or through HTML name <ruleKey>.html located in package src/resources/org/sonar/l10n/php/rules/<repositoryKey>
+ description = "<p>Property name should not be prefixed with an underscore to indicate visibility</p>"
+  )
+public class FieldNameWithUnderScorePrefixUseCheck extends PHPSubscriptionCheck {
+
+  public static final String KEY = "S4";
+  private static final String MESSAGE = "Property name \"%s\" should not be prefixed with an underscore to indicate visibility";
+
+  private static final Set<String> VISIBILITIES = ImmutableSet.of(
+          PHPKeyword.PROTECTED.getValue());
+
+
+  /*@Override
+  public void visitVariableDeclaration(VariableDeclarationTree tree) {
+    super.visitVariableDeclaration(tree);
+    System.out.println("Class tree: " + tree);
+  }*/
+
+
+  private void checkVariable(VariableDeclarationTree member, @Nullable String className) {
+    if (!member.equalToken().text().isEmpty()) {
+      String memberName = member.identifier().text();
+      if(memberName.startsWith("$_")){
+        String message = String.format(MESSAGE, "variable", memberName);
+        context().newIssue(this, member.identifier(), message);
+      }
+
+    }
+  }
+
+  @Override
+  public List<Kind> nodesToVisit() {
+    return ImmutableList.of(Kind.CLASS_PROPERTY_DECLARATION);
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+    //super.visitNode(tree);
+    ClassPropertyDeclarationTree property = (ClassPropertyDeclarationTree) tree;
+    if(property.hasModifiers()){
+      //System.out.println("Inside");
+      for (VariableDeclarationTree variableDeclarationTree : property.declarations()) {
+        String propertyName = variableDeclarationTree.identifier().text();
+        //System.out.println("Property name: " + propertyName);
+        if(propertyName.startsWith("$_")){
+          String message = String.format(MESSAGE, propertyName, propertyName);
+          //context().newFileIssue(this, message)
+          context().newIssue(this, variableDeclarationTree.identifier(), message);
+        }
+      }
+    }
+
+  }
+
+}

--- a/php-custom-rules/src/main/java/org/sonar/samples/php/checks/ProtectedMembersUseCheck.java
+++ b/php-custom-rules/src/main/java/org/sonar/samples/php/checks/ProtectedMembersUseCheck.java
@@ -1,0 +1,113 @@
+/*
+ * SonarQube PHP Custom Rules Example
+ * Copyright (C) 2016-2016 SonarSource SA
+ * mailto:contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.samples.php.checks;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import org.sonar.check.Priority;
+import org.sonar.check.Rule;
+import org.sonar.php.api.PHPKeyword;
+import org.sonar.plugins.php.api.tree.Tree;
+import org.sonar.plugins.php.api.tree.Tree.Kind;
+import org.sonar.plugins.php.api.tree.declaration.ClassPropertyDeclarationTree;
+import org.sonar.plugins.php.api.tree.declaration.MethodDeclarationTree;
+import org.sonar.plugins.php.api.tree.lexical.SyntaxToken;
+import org.sonar.plugins.php.api.visitors.PHPSubscriptionCheck;
+import org.sonar.plugins.php.api.visitors.PHPVisitorCheck;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Example of implementation of a check by extending {@link PHPVisitorCheck}.
+ * PHPVisitorCheck provides methods to visit nodes of the Abstract Syntax Tree
+ * that represents the source code.
+ * <p>
+ * Those methods can be overridden to process information
+ * related to node and issue can be created via the context that can be
+ * accessed through {@link PHPVisitorCheck#context()}.
+ */
+@Rule(
+  key = ProtectedMembersUseCheck.KEY,
+  priority = Priority.MAJOR,
+  name = "Protected class member should not be used.",
+  tags = {"convention"},
+// Description can either be given in this annotation or through HTML name <ruleKey>.html located in package src/resources/org/sonar/l10n/php/rules/<repositoryKey>
+ description = "<p>The use of protected class member is discouraged</p>"
+  )
+public class ProtectedMembersUseCheck extends PHPSubscriptionCheck {
+
+  public static final String KEY = "S3";
+  private static final String MESSAGE = "Use of protected class members is discouraged.";
+
+  private static final Set<String> VISIBILITIES = ImmutableSet.of(
+          PHPKeyword.PROTECTED.getValue());
+
+  @Override
+  public List<Kind> nodesToVisit() {
+    return ImmutableList.of(Kind.CLASS_PROPERTY_DECLARATION, Kind.METHOD_DECLARATION);
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+
+    if(tree.getKind().equals(Kind.CLASS_PROPERTY_DECLARATION)){
+      ClassPropertyDeclarationTree property = (ClassPropertyDeclarationTree) tree;
+      if(hasProtectedVisibilityModifier(property)){
+        System.out.println("Class property:"+ property);
+        String message = String.format(MESSAGE, property);
+        //context().newFileIssue(this, message)
+        context().newIssue(this, property, MESSAGE);
+      }
+
+    }else{
+      MethodDeclarationTree method = (MethodDeclarationTree) tree;
+      if(hasProtectedVisibilityModifier(method)){
+        System.out.println("Method:"+ method);
+        String message = String.format(MESSAGE, method);
+        //context().newFileIssue(this, message)
+        context().newIssue(this, method, MESSAGE);
+      }
+
+    }
+
+  }
+
+
+  private static boolean hasProtectedVisibilityModifier(MethodDeclarationTree method) {
+    for (SyntaxToken modifier : method.modifiers()) {
+      if (method.modifiers().size() == 1 && VISIBILITIES.contains(modifier.text().toLowerCase(Locale.ENGLISH))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean hasProtectedVisibilityModifier(ClassPropertyDeclarationTree property) {
+    for (SyntaxToken modifier : property.modifierTokens()) {
+      if (VISIBILITIES.contains(modifier.text().toLowerCase(Locale.ENGLISH))) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/php-custom-rules/src/main/java/org/sonar/samples/php/checks/ProtectedMembersUseCheckBKP.java
+++ b/php-custom-rules/src/main/java/org/sonar/samples/php/checks/ProtectedMembersUseCheckBKP.java
@@ -1,0 +1,138 @@
+/*
+ * SonarQube PHP Custom Rules Example
+ * Copyright (C) 2016-2016 SonarSource SA
+ * mailto:contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.samples.php.checks;
+
+import com.google.common.collect.ImmutableSet;
+
+import org.sonar.check.Priority;
+import org.sonar.check.Rule;
+import org.sonar.php.api.PHPKeyword;
+import org.sonar.plugins.php.api.tree.Tree.Kind;
+import org.sonar.plugins.php.api.tree.declaration.ClassDeclarationTree;
+import org.sonar.plugins.php.api.tree.declaration.ClassMemberTree;
+import org.sonar.plugins.php.api.tree.declaration.ClassTree;
+import org.sonar.plugins.php.api.tree.declaration.MethodDeclarationTree;
+import org.sonar.plugins.php.api.tree.declaration.VariableDeclarationTree;
+import org.sonar.plugins.php.api.tree.expression.AnonymousClassTree;
+import org.sonar.plugins.php.api.tree.lexical.SyntaxToken;
+import org.sonar.plugins.php.api.visitors.PHPVisitorCheck;
+
+import java.util.Locale;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+/**
+ * Example of implementation of a check by extending {@link PHPVisitorCheck}.
+ * PHPVisitorCheck provides methods to visit nodes of the Abstract Syntax Tree
+ * that represents the source code.
+ * <p>
+ * Those methods can be overridden to process information
+ * related to node and issue can be created via the context that can be
+ * accessed through {@link PHPVisitorCheck#context()}.
+ */
+@Rule(
+  key = ProtectedMembersUseCheckBKP.KEY,
+  priority = Priority.MAJOR,
+  name = "Protected class member should not be used.",
+  tags = {"convention"},
+// Description can either be given in this annotation or through HTML name <ruleKey>.html located in package src/resources/org/sonar/l10n/php/rules/<repositoryKey>
+ description = "<p>The use of protected class member is discouraged</p>"
+  )
+public class ProtectedMembersUseCheckBKP extends PHPVisitorCheck {
+
+  public static final String KEY = "S3";
+  private static final String MESSAGE = "Remove the protected visibility of this %s \"%s\".";
+
+  private static final Set<String> VISIBILITIES = ImmutableSet.of(
+          PHPKeyword.PROTECTED.getValue());
+
+  @Override
+  public void visitClassDeclaration(ClassDeclarationTree tree) {
+    super.visitClassDeclaration(tree);
+
+    if (tree.is(Kind.CLASS_DECLARATION)) {
+      visitClass(tree, tree.name().text());
+    }
+  }
+
+  @Override
+  public void visitAnonymousClass(AnonymousClassTree tree) {
+    super.visitAnonymousClass(tree);
+
+    visitClass(tree, null);
+  }
+
+  private void visitClass(ClassTree classTree, @Nullable String name) {
+    for (ClassMemberTree member : classTree.members()) {
+
+      if (member.is(Kind.METHOD_DECLARATION)) {
+        checkMethod((MethodDeclarationTree) member, name);
+      }else if(member.is(Kind.VARIABLE_DECLARATION)){
+        checkVariable((VariableDeclarationTree)member, name);
+      }
+    }
+  }
+
+  private void checkVariable(VariableDeclarationTree member, @Nullable String className) {
+    if (hasVariableVisibilityModifier(member)) {
+      String memberName = member.identifier().text();
+      String message = String.format(MESSAGE, "variable", memberName);
+      context().newIssue(this, member.identifier(), message);
+    }
+  }
+
+  private void checkMethod(MethodDeclarationTree method, @Nullable String className) {
+    if (hasVisibilityModifier(method)) {
+      String methodName = method.name().text();
+      String message = String.format(MESSAGE, getMethodKind(methodName, className), methodName);
+      context().newIssue(this, method.name(), message);
+    }
+  }
+
+  private static boolean hasVisibilityModifier(MethodDeclarationTree method) {
+    for (SyntaxToken modifier : method.modifiers()) {
+      if (VISIBILITIES.contains(modifier.text().toLowerCase(Locale.ENGLISH))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean hasVariableVisibilityModifier(VariableDeclarationTree member) {
+    if (VISIBILITIES.contains(member.equalToken().text().toLowerCase(Locale.ENGLISH))) {
+      return true;
+    }
+    return false;
+  }
+
+  private static String getMethodKind(String methodName, @Nullable String className) {
+    if ("__construct".equalsIgnoreCase(methodName) || methodName.equalsIgnoreCase(className)) {
+      return "constructor";
+
+    } else if ("__destruct".equalsIgnoreCase(methodName)) {
+      return "destructor";
+
+    } else {
+      return "method";
+    }
+  }
+
+}

--- a/php-custom-rules/src/main/resources/org/sonar/l10n/php/rules/custom/S3.html
+++ b/php-custom-rules/src/main/resources/org/sonar/l10n/php/rules/custom/S3.html
@@ -1,0 +1,3 @@
+<p>
+    Protected class member should not be used.
+</p>

--- a/php-custom-rules/src/main/resources/org/sonar/l10n/php/rules/custom/S4.html
+++ b/php-custom-rules/src/main/resources/org/sonar/l10n/php/rules/custom/S4.html
@@ -1,0 +1,3 @@
+<p>
+    Property name should not be prefixed with an underscore to indicate visibility
+</p>

--- a/php-custom-rules/src/test/java/org/sonar/samples/php/MyPhpRulesTest.java
+++ b/php-custom-rules/src/test/java/org/sonar/samples/php/MyPhpRulesTest.java
@@ -13,6 +13,6 @@ public class MyPhpRulesTest {
     RulesDefinition.Context context = new RulesDefinition.Context();
     rulesDefinition.define(context);
     RulesDefinition.Repository repository = context.repository("custom");
-    assertEquals(2, repository.rules().size());
+    assertEquals(4, repository.rules().size());
   }
 }

--- a/php-custom-rules/src/test/java/org/sonar/samples/php/checks/FieldNameWithUnderScorePrefixUseCheckTest.java
+++ b/php-custom-rules/src/test/java/org/sonar/samples/php/checks/FieldNameWithUnderScorePrefixUseCheckTest.java
@@ -20,20 +20,20 @@
 package org.sonar.samples.php.checks;
 
 import org.junit.Test;
-import org.sonar.plugins.php.api.tests.PhpTestFile;
 import org.sonar.plugins.php.api.tests.PHPCheckTest;
+import org.sonar.plugins.php.api.tests.PhpTestFile;
 
 import java.io.File;
 
 /**
  * Test class to test the check implementation.
  */
-public class OtherForbiddenFunctionUseCheckTest {
+public class FieldNameWithUnderScorePrefixUseCheckTest {
 
   @Test
   public void test() throws Exception {
-    PHPCheckTest.check(new OtherForbiddenFunctionUseCheck(), new PhpTestFile(new File("src/test/resources/checks" +
-            "/forbiddenFunctionUseCheck.php")));
+    PHPCheckTest.check(new FieldNameWithUnderScorePrefixUseCheck(),
+            new PhpTestFile(new File("src/test/resources/checks/fieldNameWithUnderscoreUseCheck.php")));
   }
 
 }

--- a/php-custom-rules/src/test/java/org/sonar/samples/php/checks/ProtectedMembersUseCheckTest.java
+++ b/php-custom-rules/src/test/java/org/sonar/samples/php/checks/ProtectedMembersUseCheckTest.java
@@ -20,20 +20,19 @@
 package org.sonar.samples.php.checks;
 
 import org.junit.Test;
-import org.sonar.plugins.php.api.tests.PhpTestFile;
 import org.sonar.plugins.php.api.tests.PHPCheckTest;
+import org.sonar.plugins.php.api.tests.PhpTestFile;
 
 import java.io.File;
 
 /**
  * Test class to test the check implementation.
  */
-public class OtherForbiddenFunctionUseCheckTest {
+public class ProtectedMembersUseCheckTest {
 
   @Test
   public void test() throws Exception {
-    PHPCheckTest.check(new OtherForbiddenFunctionUseCheck(), new PhpTestFile(new File("src/test/resources/checks" +
-            "/forbiddenFunctionUseCheck.php")));
+    PHPCheckTest.check(new ProtectedMembersUseCheck(), new PhpTestFile(new File("src/test/resources/checks/protectedClassMemberCheck.php")));
   }
 
 }

--- a/php-custom-rules/src/test/resources/checks/fieldNameWithUnderscoreUseCheck.php
+++ b/php-custom-rules/src/test/resources/checks/fieldNameWithUnderscoreUseCheck.php
@@ -1,0 +1,9 @@
+<?php
+
+class myClass {
+
+  public $_myVariable;  // NOK {{Property name "$_myVariable" should not be prefixed with an underscore to indicate visibility}}
+  public $myVariable;      // OK
+  private $myVariable;      // OK
+
+}

--- a/php-custom-rules/src/test/resources/checks/protectedClassMemberCheck.php
+++ b/php-custom-rules/src/test/resources/checks/protectedClassMemberCheck.php
@@ -1,0 +1,16 @@
+<?php
+
+class C1
+{
+    protected function foo() { return; }    // NOK {{Use of protected class members is discouraged.}}
+
+    private static function i() { return; }  // OK
+    protected abstract function bar() { return; }         // OK
+    public function k() { return; }          // OK
+
+    protected $myVariable;  // NOK {{Use of protected class members is discouraged.}}
+    public $myVariable;      // OK
+    private static $myVariable;      // OK
+    private $myVariable;      // OK
+}
+


### PR DESCRIPTION
1. Protected class member should not be used.
2. Property name should not be prefixed with an underscore to indicate visibility